### PR TITLE
Fix meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,8 +14,6 @@
 
     <link rel="author" href="%PUBLIC_URL%/humans.txt" />
     <link rel="canonical" href="%PUBLIC_URL%" />
-    <meta property="og:url" content="%PUBLIC_URL%" />
-    <meta name="twitter:url" content="%PUBLIC_URL%" />
 
     <!--
       Added by `react-helmet`:

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <link rel="author" href="%PUBLIC_URL%/humans.txt" />
-    <link rel="canonical" href="%PUBLIC_URL%" />
 
     <!--
       Added by `react-helmet`:

--- a/src/components/colophon/index.tsx
+++ b/src/components/colophon/index.tsx
@@ -41,50 +41,58 @@ const Colophon: FC<{ author: string; handle: string }> = ({
       <pre>colophon</pre>
     </h2>
     <p>
-      this site has been lovingly crafted by{' '}
-      <a href={`https://github.com/${handle.substring(1)}`}>{author}</a> (
-      <a href={`https://twitter.com/${handle.substring(1)}`}>{handle}</a>). you
-      may{' '}
-      <a
-        href={`https://github.com/mysterycommand/${name}/tree/v${version}`}
-        title={`mysterycommand/${name}@${version}`}
-        rel="external"
-      >
-        view the source
-      </a>{' '}
-      at your leisure, and if you see a bug or a typo please be so kind as to{' '}
-      <a href={bugs.url} title="see a bug? create an issue!" rel="external">
-        create an issue
-      </a>
+      {[
+        'this site has been lovingly crafted by ',
+        <a href={`https://github.com/${handle.substring(1)}`}>{author}</a>,
+        ' (',
+        <a href={`https://twitter.com/${handle.substring(1)}`}>{handle}</a>,
+        ') you may ',
+        <a
+          href={`https://github.com/mysterycommand/${name}/tree/v${version}`}
+          title={`mysterycommand/${name}@${version}`}
+          rel="external"
+        >
+          view the source
+        </a>,
+        ' at your leisure, and if you see a bug or a typo please be so kind ',
+        'as to ',
+        <a href={bugs.url} title="see a bug? create an issue!" rel="external">
+          create an issue
+        </a>,
+      ]}
     </p>
     <div>
-      this project would not be possible without the work of these fine open
-      source projects:{' '}
-      <Hlist>
-        {links.map(({ props, text }) => (
-          <a key={props.title} {...props}>
-            {text}
-          </a>
-        ))}
-      </Hlist>
-    </div>
-    <div>
-      copyright © {new Date().getFullYear()} {author}, licensed:{' '}
-      <Hlist className="licenses">
-        {license
-          .substring(1, license.length - 1)
-          .split(' OR ')
-          .map(lic => (
-            <a
-              key={lic}
-              href={`https://github.com/mysterycommand/${name}/blob/v${version}/LICENSE-${lic}`}
-              title={lic}
-              rel="external"
-            >
-              {lic}
+      {[
+        'this project would not be possible without the work of these fine ',
+        'open source projects: ',
+        <Hlist>
+          {links.map(({ props, text }) => (
+            <a key={props.title} {...props}>
+              {text}
             </a>
           ))}
-      </Hlist>
+        </Hlist>,
+      ]}
+    </div>
+    <div>
+      {[
+        `copyright © ${new Date().getFullYear()} ${author}, licensed: `,
+        <Hlist className="licenses">
+          {license
+            .substring(1, license.length - 1)
+            .split(' OR ')
+            .map(lic => (
+              <a
+                key={lic}
+                href={`https://github.com/mysterycommand/${name}/blob/v${version}/LICENSE-${lic}`}
+                title={lic}
+                rel="external"
+              >
+                {lic}
+              </a>
+            ))}
+        </Hlist>,
+      ]}
     </div>
   </footer>
 );

--- a/src/components/colophon/index.tsx
+++ b/src/components/colophon/index.tsx
@@ -41,58 +41,50 @@ const Colophon: FC<{ author: string; handle: string }> = ({
       <pre>colophon</pre>
     </h2>
     <p>
-      {[
-        'this site has been lovingly crafted by ',
-        <a href={`https://github.com/${handle.substring(1)}`}>{author}</a>,
-        ' (',
-        <a href={`https://twitter.com/${handle.substring(1)}`}>{handle}</a>,
-        ') you may ',
-        <a
-          href={`https://github.com/mysterycommand/${name}/tree/v${version}`}
-          title={`mysterycommand/${name}@${version}`}
-          rel="external"
-        >
-          view the source
-        </a>,
-        ' at your leisure, and if you see a bug or a typo please be so kind ',
-        'as to ',
-        <a href={bugs.url} title="see a bug? create an issue!" rel="external">
-          create an issue
-        </a>,
-      ]}
+      this site has been lovingly crafted by
+      <a href={`https://github.com/${handle.substring(1)}`}>{author}</a>(
+      <a href={`https://twitter.com/${handle.substring(1)}`}>{handle}</a>) you
+      may
+      <a
+        href={`https://github.com/mysterycommand/${name}/tree/v${version}`}
+        title={`mysterycommand/${name}@${version}`}
+        rel="external"
+      >
+        view the source
+      </a>
+      at your leisure, and if you see a bug or a typo please be so kind as to
+      <a href={bugs.url} title="see a bug? create an issue!" rel="external">
+        create an issue
+      </a>
     </p>
     <div>
-      {[
-        'this project would not be possible without the work of these fine ',
-        'open source projects: ',
-        <Hlist>
-          {links.map(({ props, text }) => (
-            <a key={props.title} {...props}>
-              {text}
-            </a>
-          ))}
-        </Hlist>,
-      ]}
+      this project would not be possible without the work of these fine open
+      source projects:
+      <Hlist>
+        {links.map(({ props, text }) => (
+          <a key={props.title} {...props}>
+            {text}
+          </a>
+        ))}
+      </Hlist>
     </div>
     <div>
-      {[
-        `copyright © ${new Date().getFullYear()} ${author}, licensed: `,
-        <Hlist className="licenses">
-          {license
-            .substring(1, license.length - 1)
-            .split(' OR ')
-            .map(lic => (
-              <a
-                key={lic}
-                href={`https://github.com/mysterycommand/${name}/blob/v${version}/LICENSE-${lic}`}
-                title={lic}
-                rel="external"
-              >
-                {lic}
-              </a>
-            ))}
-        </Hlist>,
-      ]}
+      copyright © {new Date().getFullYear()} {author}, licensed:
+      <Hlist className="licenses">
+        {license
+          .substring(1, license.length - 1)
+          .split(' OR ')
+          .map(lic => (
+            <a
+              key={lic}
+              href={`https://github.com/mysterycommand/${name}/blob/v${version}/LICENSE-${lic}`}
+              title={lic}
+              rel="external"
+            >
+              {lic}
+            </a>
+          ))}
+      </Hlist>
     </div>
   </footer>
 );

--- a/src/components/colophon/index.tsx
+++ b/src/components/colophon/index.tsx
@@ -24,7 +24,7 @@ const links: {
   props: {
     href:
       key === 'node'
-        ? `https://nodejs.org/dist/v${value}/docs/api/`
+        ? `https://nodejs.org/en/`
         : `https://www.npmjs.com/package/${key}`,
     title: `${key}@${value}`,
     rel: 'external',
@@ -37,29 +37,28 @@ const Colophon: FC<{ author: string; handle: string }> = ({
   handle,
 }) => (
   <footer className="colophon">
-    <h2>
-      <pre>colophon</pre>
-    </h2>
+    <h2>colophon</h2>
     <p>
-      this site has been lovingly crafted by
-      <a href={`https://github.com/${handle.substring(1)}`}>{author}</a>(
+      this site has been lovingly crafted by{' '}
+      <a href={`https://github.com/${handle.substring(1)}`}>{author}</a> (
       <a href={`https://twitter.com/${handle.substring(1)}`}>{handle}</a>) you
-      may
+      may{' '}
       <a
         href={`https://github.com/mysterycommand/${name}/tree/v${version}`}
         title={`mysterycommand/${name}@${version}`}
         rel="external"
       >
         view the source
-      </a>
-      at your leisure, and if you see a bug or a typo please be so kind as to
+      </a>{' '}
+      at your leisure, and if you see a bug or a typo please be so kind as to{' '}
       <a href={bugs.url} title="see a bug? create an issue!" rel="external">
         create an issue
-      </a>
+      </a>{' '}
+      … and thanks for visiting
     </p>
     <div>
       this project would not be possible without the work of these fine open
-      source projects:
+      source projects:{' '}
       <Hlist>
         {links.map(({ props, text }) => (
           <a key={props.title} {...props}>
@@ -69,7 +68,7 @@ const Colophon: FC<{ author: string; handle: string }> = ({
       </Hlist>
     </div>
     <div>
-      copyright © {new Date().getFullYear()} {author}, licensed:
+      copyright © {new Date().getFullYear()} {author}, licensed:{' '}
       <Hlist className="licenses">
         {license
           .substring(1, license.length - 1)

--- a/src/components/colophon/style.css
+++ b/src/components/colophon/style.css
@@ -14,7 +14,7 @@
   color: #fafafa;
 }
 
-.colophon a:hover {
+.colophon a {
   text-decoration: underline;
 }
 

--- a/src/components/head/facebook-meta/index.test.tsx
+++ b/src/components/head/facebook-meta/index.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import FacebookMeta from '.';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(
+    <FacebookMeta
+      title="Matt Hayes is @mysterycommand"
+      imagePath="https://mysterycommand.com/screenshots/twitter/index.png"
+      imageAlt="a screenshot of Matt Hayes' website"
+    />,
+    div,
+  );
+  unmountComponentAtNode(div);
+});

--- a/src/components/head/facebook-meta/index.tsx
+++ b/src/components/head/facebook-meta/index.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+
+const FACEBOOK_ID = '163000679';
+
+const FacebookMeta: FC<{
+  title: string;
+  imagePath: string;
+  imageAlt: string;
+}> = ({ title, imagePath, imageAlt }) => (
+  <>
+    <meta property="fb:admins" content={FACEBOOK_ID} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content={title} />
+    <meta property="og:image" content={imagePath} />
+    <meta property="og:image:alt" content={imageAlt} />
+    <meta property="og:locale" content="en_US" />
+  </>
+);
+
+export default FacebookMeta;

--- a/src/components/head/index.tsx
+++ b/src/components/head/index.tsx
@@ -3,7 +3,35 @@ import { Helmet } from 'react-helmet';
 
 import { homepage } from '../../../package.json';
 
+/**
+ * @see: https://github.com/nfl/react-helmet/issues/342
+ */
+// import TwitterMeta from './twitter-meta';
+// import FacebookMeta from './facebook-meta';
+// import SharedMeta from './shared-meta';
+
 const FACEBOOK_ID = '163000679';
+
+function getShortDescription(descs: string[]): string {
+  let temp = descs;
+  let shortDescription;
+
+  while ((shortDescription = temp.concat('etc…').join(', ')).length > 200) {
+    temp.pop();
+  }
+
+  return shortDescription;
+}
+
+const { pathname, href } = window.location;
+const { origin } = new URL(
+  process.env.NODE_ENV === 'production' ? homepage : href,
+);
+function getImagePath(network: string): string {
+  return `${origin}/screenshots/${network}/${
+    pathname === '/' ? 'index.png' : pathname.replace('html', 'png')
+  }`;
+}
 
 const Head: FC<{
   author: string;
@@ -13,26 +41,10 @@ const Head: FC<{
 }> = ({ author, handle, titles, descriptors }) => {
   const title = `${author} is ${handle}`;
 
-  const descs = titles.concat(descriptors);
-  const longDescription = `artist, ${descs.join(', ')}`;
-  const shortDescription = (() => {
-    let shortenedDescs = descs;
-    let description = `artist, ${shortenedDescs.join(', ')}, etc…`;
-    while (description.length > 200) {
-      shortenedDescs.pop();
-      description = `artist, ${shortenedDescs.join(', ')}, etc…`;
-    }
-    return description;
-  })();
+  const descs = ['artist'].concat(titles, descriptors);
+  const longDescription = descs.join(', ');
+  const shortDescription = getShortDescription(descs);
 
-  const { origin } = new URL(
-    process.env.NODE_ENV === 'production' ? homepage : window.location.href,
-  );
-  const { pathname } = window.location;
-  const image = (network: string) =>
-    `${origin}/screenshots/${network}/${
-      pathname === '/' ? 'index.png' : pathname.replace('html', 'png')
-    }`;
   const imageAlt = `a screenshot of ${author}'${
     author.endsWith('s') ? '' : 's'
   } website`;
@@ -43,26 +55,47 @@ const Head: FC<{
         <title>{title}</title>
         <meta name="author" content={author} />
         <meta name="description" content={longDescription} />
+        <link rel="canonical" href={homepage} />
 
-        {/* Facebook */}
-        <meta property="fb:admins" content={FACEBOOK_ID} />
+        {/* @see: https://github.com/nfl/react-helmet/issues/342 */}
+        {/*
+        <SharedMeta
+          homepage={homepage}
+          title={title}
+          shortDescription={shortDescription}
+        />
+
+        <FacebookMeta
+          title={title}
+          imagePath={getImagePath('facebook')}
+          imageAlt={imageAlt}
+        />
+
+        <TwitterMeta
+          handle={handle}
+          imagePath={getImagePath('twitter')}
+          imageAlt={imageAlt}
+        />
+        */}
+
+        {/* SharedMeta */}
         <meta property="og:url" content={homepage} />
-        <meta property="og:type" content="website" />
         <meta property="og:title" content={title} />
-        <meta property="og:image" content={image('facebook')} />
-        <meta property="og:image:alt" content={imageAlt} />
         <meta property="og:description" content={shortDescription} />
+
+        {/* FacebookMeta */}
+        <meta property="fb:admins" content={FACEBOOK_ID} />
+        <meta property="og:type" content="website" />
         <meta property="og:site_name" content={title} />
+        <meta property="og:image" content={getImagePath('facebook')} />
+        <meta property="og:image:alt" content={imageAlt} />
         <meta property="og:locale" content="en_US" />
 
-        {/* Twitter */}
-        <meta name="twitter:url" content={homepage} />
+        {/* TwitterMeta */}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content={handle} />
         <meta name="twitter:creator" content={handle} />
-        <meta name="twitter:title" content={title} />
-        <meta name="twitter:description" content={shortDescription} />
-        <meta name="twitter:image" content={image('twitter')} />
+        <meta name="twitter:image" content={getImagePath('twitter')} />
         <meta name="twitter:image:alt" content={imageAlt} />
       </Helmet>
     </>

--- a/src/components/head/index.tsx
+++ b/src/components/head/index.tsx
@@ -1,6 +1,10 @@
 import React, { FC } from 'react';
 import { Helmet } from 'react-helmet';
 
+import { homepage } from '../../../package.json';
+
+const FACEBOOK_ID = '163000679';
+
 const Head: FC<{
   author: string;
   handle: string;
@@ -21,7 +25,10 @@ const Head: FC<{
     return description;
   })();
 
-  const { origin, pathname } = window.location;
+  const { origin } = new URL(
+    process.env.NODE_ENV === 'production' ? homepage : window.location.href,
+  );
+  const { pathname } = window.location;
   const image = (network: string) =>
     `${origin}/screenshots/${network}/${
       pathname === '/' ? 'index.png' : pathname.replace('html', 'png')
@@ -38,7 +45,8 @@ const Head: FC<{
         <meta name="description" content={longDescription} />
 
         {/* Facebook */}
-        <meta property="og:url" content={process.env.PUBLIC_URL} />
+        <meta property="fb:admins" content={FACEBOOK_ID} />
+        <meta property="og:url" content={homepage} />
         <meta property="og:type" content="website" />
         <meta property="og:title" content={title} />
         <meta property="og:image" content={image('facebook')} />
@@ -46,10 +54,9 @@ const Head: FC<{
         <meta property="og:description" content={shortDescription} />
         <meta property="og:site_name" content={title} />
         <meta property="og:locale" content="en_US" />
-        <meta property="article:author" content={author} />
 
         {/* Twitter */}
-        <meta name="twitter:url" content={process.env.PUBLIC_URL} />
+        <meta name="twitter:url" content={homepage} />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content={handle} />
         <meta name="twitter:creator" content={handle} />

--- a/src/components/head/index.tsx
+++ b/src/components/head/index.tsx
@@ -3,13 +3,6 @@ import { Helmet } from 'react-helmet';
 
 import { homepage } from '../../../package.json';
 
-/**
- * @see: https://github.com/nfl/react-helmet/issues/342
- */
-// import TwitterMeta from './twitter-meta';
-// import FacebookMeta from './facebook-meta';
-// import SharedMeta from './shared-meta';
-
 const FACEBOOK_ID = '163000679';
 
 function getShortDescription(descs: string[]): string {
@@ -56,27 +49,6 @@ const Head: FC<{
         <meta name="author" content={author} />
         <meta name="description" content={longDescription} />
         <link rel="canonical" href={homepage} />
-
-        {/* @see: https://github.com/nfl/react-helmet/issues/342 */}
-        {/*
-        <SharedMeta
-          homepage={homepage}
-          title={title}
-          shortDescription={shortDescription}
-        />
-
-        <FacebookMeta
-          title={title}
-          imagePath={getImagePath('facebook')}
-          imageAlt={imageAlt}
-        />
-
-        <TwitterMeta
-          handle={handle}
-          imagePath={getImagePath('twitter')}
-          imageAlt={imageAlt}
-        />
-        */}
 
         {/* SharedMeta */}
         <meta property="og:url" content={homepage} />

--- a/src/components/head/index.tsx
+++ b/src/components/head/index.tsx
@@ -38,6 +38,7 @@ const Head: FC<{
         <meta name="description" content={longDescription} />
 
         {/* Facebook */}
+        <meta property="og:url" content={process.env.PUBLIC_URL} />
         <meta property="og:type" content="website" />
         <meta property="og:title" content={title} />
         <meta property="og:image" content={image('facebook')} />
@@ -48,6 +49,7 @@ const Head: FC<{
         <meta property="article:author" content={author} />
 
         {/* Twitter */}
+        <meta name="twitter:url" content={process.env.PUBLIC_URL} />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content={handle} />
         <meta name="twitter:creator" content={handle} />

--- a/src/components/head/shared-meta/index.test.tsx
+++ b/src/components/head/shared-meta/index.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import SharedMeta from '.';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(
+    <SharedMeta
+      homepage="https://mysterycommand.com"
+      title="Matt Hayes is @mysterycommand"
+      shortDescription={[
+        'artist',
+        'computer programmer',
+        'creative technologist',
+        'game maker',
+        'software engineer',
+        'solutions architect',
+        'web developer',
+        'analyst',
+        'dabbler',
+        'dilettante',
+        'generalist',
+        'philosopher',
+        'tinkerer',
+        'etc…',
+      ].join(', ')}
+    />,
+    div,
+  );
+  unmountComponentAtNode(div);
+});

--- a/src/components/head/shared-meta/index.tsx
+++ b/src/components/head/shared-meta/index.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react';
+
+const SharedMeta: FC<{
+  homepage: string;
+  title: string;
+  shortDescription: string;
+}> = ({ homepage, title, shortDescription }) => (
+  <>
+    <meta property="og:url" content={homepage} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={shortDescription} />
+  </>
+);
+
+export default SharedMeta;

--- a/src/components/head/twitter-meta/index.test.tsx
+++ b/src/components/head/twitter-meta/index.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import TwitterMeta from '.';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(
+    <TwitterMeta
+      handle="@mysterycommand"
+      imagePath="https://mysterycommand.com/screenshots/twitter/index.png"
+      imageAlt="a screenshot of Matt Hayes' website"
+    />,
+    div,
+  );
+  unmountComponentAtNode(div);
+});

--- a/src/components/head/twitter-meta/index.tsx
+++ b/src/components/head/twitter-meta/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react';
+
+const TwitterMeta: FC<{
+  handle: string;
+  imagePath: string;
+  imageAlt: string;
+}> = ({ handle, imagePath, imageAlt }) => (
+  <>
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content={handle} />
+    <meta name="twitter:creator" content={handle} />
+    <meta name="twitter:image" content={imagePath} />
+    <meta name="twitter:image:alt" content={imageAlt} />
+  </>
+);
+
+export default TwitterMeta;


### PR DESCRIPTION
Got some stuff wrong with the `og` tags in the first iteration, this _should_ fix that. Also some minor tweaks to the `colophon`. Also adds a couple components to try and group `meta` tags by network ("shared", Facebook, and Twitter) … but they're not/can't be used until nfl/react-helmet#342 gets fixed.